### PR TITLE
#8: Removed <#ftl encoding="utf-8"> from all queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ First is use [StrQuery.java](src%2Fmain%2Fjava%2Forg%2Ffmrk4sql%2FStrQuery.java)
 for parse freemarker template from String view:
 
 ```java
-final Query query = new StrQuery("<#ftl encoding=\"utf-8\">\nselect count()");
+final Query query = new StrQuery("select count()");
 query.parse(FmParams.EMPTY);
 ```
 
@@ -43,7 +43,6 @@ For example we can have single query where in some case we can switch off pagina
 
 So template will be look like this:
 ```xml
-<#ftl encoding="utf-8">
 <#-- @vtlvariable name="union" type="java.lang.Boolean" -->
 select foo, bar from foo_table
 <#if union==true>
@@ -62,7 +61,7 @@ select foo, bar from bar_table
 ```
 
 ```java
-final Query query = new StrQuery("<#ftl encoding=\"utf-8\">\nselect count()");
+final Query query = new StrQuery("select count()");
 query.parse(FmParams.EMPTY);
 ```
 

--- a/src/test/java/org/fmrk4sql/StrQueryTest.java
+++ b/src/test/java/org/fmrk4sql/StrQueryTest.java
@@ -43,14 +43,9 @@ import org.springframework.data.domain.Sort;
  */
 final class StrQueryTest {
 
-    /**
-     * Header of ftl files.
-     */
-    private static final String FTL_ENCODING = "<#ftl encoding=\"utf-8\">";
-
     @Test
     void parseSimpleQueryNoParam() throws TemplateException, IOException {
-        final Query query = new StrQuery("<#ftl encoding=\"utf-8\">\nselect count()");
+        final Query query = new StrQuery("select count()");
         Assertions.assertEquals("select count()", query.parse(FmParams.EMPTY));
     }
 
@@ -58,7 +53,6 @@ final class StrQueryTest {
     void parseSimpleQueryIfBoolean() throws TemplateException, IOException {
         final String template = String.join(
             "",
-            StrQueryTest.FTL_ENCODING,
             "<#-- @vtlvariable name=\"plan\" type=\"java.lang.Boolean\" -->",
             "<#if plan==true>",
             "select sum(plan_value) from table",
@@ -75,7 +69,6 @@ final class StrQueryTest {
     void parseSimpleQueryTableName() throws TemplateException, IOException {
         final String template =  String.join(
             "",
-            StrQueryTest.FTL_ENCODING,
             "select sum(plan_value) from ${table_name}"
         );
         final Params params = new FmParams(
@@ -90,7 +83,6 @@ final class StrQueryTest {
     void parsePageableParams() throws TemplateException, IOException {
         final String template = String.join(
             "",
-            StrQueryTest.FTL_ENCODING,
             "select sum(plan_value) from ${table_name} ",
             "limit ${size} offset ${page}"
         );
@@ -110,7 +102,6 @@ final class StrQueryTest {
     void parseOnlyPageableParams() throws TemplateException, IOException {
         final String template =  String.join(
             "",
-            StrQueryTest.FTL_ENCODING,
             "select sum(plan_value) from constant_table ",
             "limit ${size} offset ${page}"
         );
@@ -130,7 +121,6 @@ final class StrQueryTest {
     void parsePageableOrderable() throws TemplateException, IOException {
         final String template =  String.join(
             "",
-            StrQueryTest.FTL_ENCODING,
             "select col1, col2 from ${table_name}",
             "<#if orders?has_content> ",
             "order by ",
@@ -163,7 +153,6 @@ final class StrQueryTest {
         );
         final String template =  String.join(
             "",
-            StrQueryTest.FTL_ENCODING,
             "select col1, col2 from ${table_name}",
             "<#if orders?has_content> ",
             "order by ",

--- a/src/test/resources/ftltest/parse_simple_query_if_boolean.sql
+++ b/src/test/resources/ftltest/parse_simple_query_if_boolean.sql
@@ -1,4 +1,3 @@
-<#ftl encoding="utf-8">
 <#-- @vtlvariable name="plan" type=\"java.lang.Boolean\" -->
 <#if plan==true>
 select sum(plan_value) from table

--- a/src/test/resources/ftltest/parse_simple_query_table_name.sql
+++ b/src/test/resources/ftltest/parse_simple_query_table_name.sql
@@ -1,2 +1,1 @@
-<#ftl encoding="utf-8">
 select sum(plan_value) from ${table_name}

--- a/src/test/resources/ftltest/simple_query_no_param.sql
+++ b/src/test/resources/ftltest/simple_query_no_param.sql
@@ -1,2 +1,1 @@
-<#ftl encoding="utf-8">
 select count()


### PR DESCRIPTION
It is not necessery header bacause of setting configurations in parser classes